### PR TITLE
Issue #180: Cursor in Tabelle nur bei auswählbaren Zeilen verändern (#180)

### DIFF
--- a/projects/lux-components-lib/src/lib/lux-common/lux-table/lux-table.component.html
+++ b/projects/lux-components-lib/src/lib/lux-common/lux-table/lux-table.component.html
@@ -196,8 +196,8 @@
             'lux-row-selected': luxSelected.has(rowData) && luxMultiSelect,
             'lux-cursor':
               luxDoubleClicked.observed ||
-              (luxSelectedChange.observed && !luxMultiSelectOnlyCheckboxClick) ||
-              (luxSelectedAsArrayChange.observed && !luxMultiSelectOnlyCheckboxClick)
+              (luxSelectedChange.observed && luxMultiSelect && !luxMultiSelectOnlyCheckboxClick) ||
+              (luxSelectedAsArrayChange.observed && luxMultiSelect && !luxMultiSelectOnlyCheckboxClick)
           }"
           (dblclick)="onDoubleClick($event, rowData)"
           (click)="onSingleClick($event, rowData, i)"


### PR DESCRIPTION
Verhindert dass der Cursor zu einem Pointer wird, wenn die Tabelle keine Auswahl (`luxMultiSelect=false`) erlaubt.

Details siehe #180