### PR TITLE
Issue #199: Berechnung der verbleibenden Sessiondauer anhand von Timestamp (#199)

### DIFF
--- a/projects/demo-app/src/app/app.consent.ts
+++ b/projects/demo-app/src/app/app.consent.ts
@@ -15,7 +15,9 @@ const CONSENT_TRANSLATION_KEYS = {
   demoConsentDescription: 'app.consent.description.demoConsent',
   themeConsentDescription: 'app.consent.description.themeConsent',
   tableConsentDescription: 'app.consent.description.tableConsent',
-  hintConsentDescription: 'app.consent.description.hintConsent'
+  hintConsentDescription: 'app.consent.description.hintConsent',
+  sessionConsentDescription: 'app.consent.description.sessionConsent',
+  durationSessionActive: 'app.consent.duration.sessionActive'
 } as const;
 
 function createTranslations(translocoService: TranslocoService): {
@@ -24,6 +26,7 @@ function createTranslations(translocoService: TranslocoService): {
   theme: ConsentEntryTranslation;
   table: ConsentEntryTranslation;
   hint: ConsentEntryTranslation;
+  session: ConsentEntryTranslation;
 } {
   return {
     appConsent: {
@@ -50,6 +53,11 @@ function createTranslations(translocoService: TranslocoService): {
       processingCountry: translocoService.translate(CONSENT_TRANSLATION_KEYS.countryGermany),
       duration: translocoService.translate(CONSENT_TRANSLATION_KEYS.persistent),
       description: translocoService.translate(CONSENT_TRANSLATION_KEYS.hintConsentDescription)
+    },
+    session: {
+      processingCountry: translocoService.translate(CONSENT_TRANSLATION_KEYS.countryGermany),
+      duration: translocoService.translate(CONSENT_TRANSLATION_KEYS.durationSessionActive),
+      description: translocoService.translate(CONSENT_TRANSLATION_KEYS.sessionConsentDescription)
     }
   };
 }
@@ -85,6 +93,14 @@ export const appConsentProvider = {
           purpose: LuxConsentPurpose.Essential,
           duration: translations.demoConsent.duration,
           description: translations.demoConsent.description
+        },
+        {
+          type: LuxConsentStorageType.LocalStorage,
+          name: 'lux-components-session-endtime',
+          processingCountry: translations.demoConsent.processingCountry,
+          purpose: LuxConsentPurpose.Essential,
+          duration: translations.session.duration,
+          description: translations.session.description
         },
         {
           type: LuxConsentStorageType.LocalStorage,

--- a/projects/demo-app/src/app/configuration/configuration.component.html
+++ b/projects/demo-app/src/app/configuration/configuration.component.html
@@ -130,6 +130,12 @@
         (luxValueChange)="updateConfig()"
         [luxNoBottomLabel]="true"
       ></lux-input-ac>
+      <lux-input-ac
+        luxLabel="Local Storage Key Name des Session-Timers"
+        [(luxValue)]="currentConfig.sessionTimerConfig!.localStorageKeyName"
+        (luxValueChange)="updateConfig()"
+        [luxNoBottomLabel]="true"
+      ></lux-input-ac>
     </lux-card-content>
   </lux-card>
 </div>

--- a/projects/demo-app/src/locale/de.json
+++ b/projects/demo-app/src/locale/de.json
@@ -6,14 +6,16 @@
       },
       "duration": {
         "365days": "365 Tage",
-        "persistent": "Dauerhaft"
+        "persistent": "Dauerhaft",
+        "sessionActive": "solange eine Sitzung aktiv ist"
       },
       "description": {
         "appConsent": "Dieses Cookie wird zur Speicherung des Consents zur Cookie-Verwendung benötigt.",
         "demoConsent": "Dieses Cookie wird zur Speicherung des Demo-Consents zur Cookie-Verwendung benötigt.",
         "themeConsent": "Speichert das Theme, mit dem die Anwendung dargestellt werden soll.",
         "tableConsent": "Speichert die Einstellungen zu Spaltenbreiten einer Tabelle der Anwendung.",
-        "hintConsent": "Speichert, ob die Anwendungstour beim nächsten Aufruf der Anwendung nochmal angezeigt werden soll."
+        "hintConsent": "Speichert, ob die Anwendungstour beim nächsten Aufruf der Anwendung nochmal angezeigt werden soll.",
+        "sessionConsent": "Wird zur Speicherung der verbleibenden Sessiondauer benötigt. Es wird mit Sitzungsende gelöscht."
       }
     },
     "menu": {

--- a/projects/demo-app/src/locale/en.json
+++ b/projects/demo-app/src/locale/en.json
@@ -6,14 +6,16 @@
       },
       "duration": {
         "365days": "365 days",
-        "persistent": "Persistent"
+        "persistent": "Persistent",
+        "sessionActive": "as long as a session is active"
       },
       "description": {
         "appConsent": "This cookie is required to store the consent for cookie usage.",
         "demoConsent": "This cookie is required to store the demo consent for cookie usage.",
         "themeConsent": "Stores the theme with which the application should be displayed.",
         "tableConsent": "Stores the settings for column widths of a table in the application.",
-        "hintConsent": "Stores whether the application tour should be shown again on the next application launch."
+        "hintConsent": "Stores whether the application tour should be shown again on the next application launch.",
+        "sessionConsent": "Required to store the remaining session duration. It will be deleted when the session ends."
       }
     },
     "menu": {

--- a/projects/lux-components-lib/src/lib/lux-components-config/lux-components-config-parameters.interface.ts
+++ b/projects/lux-components-lib/src/lib/lux-components-config/lux-components-config-parameters.interface.ts
@@ -82,5 +82,6 @@ export interface LuxComponentsConfigParameters {
     url?: string;
     httpSessionTimeHeaderName?: string;
     httpSessionProlongationHeaderName?: string;
+    localStorageKeyName?: string;
   };
 }

--- a/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
+++ b/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
@@ -22,6 +22,7 @@ export class LuxAppHeaderAcSessionTimerService {
   private dialogWasClosed = false;
   private currentDialogRef: any = null;
   protected readonly startingSeconds = signal<number>(0);
+  private endTime = 0;
   private urlValue = '';
   private canExtendSessionValue = true;
 
@@ -42,12 +43,14 @@ export class LuxAppHeaderAcSessionTimerService {
   }
 
   timeRemaining$ = toObservable(this.startingSeconds).pipe(
-    switchMap((seconds) =>
-      timer(0, 1000).pipe(
-        map((n) => (seconds - n) * 1000),
-        takeWhile((n) => n >= 0)
-      )
-    )
+    switchMap((seconds) => {
+      this.endTime = seconds > 0 ? Date.now() + seconds * 1000 : 0;
+
+      return timer(0, 1000).pipe(
+        map(() => Math.max(0, this.endTime - Date.now())),
+        takeWhile((remaining) => remaining > 0)
+      );
+    })
   );
 
   timeRemaining = toSignal(this.timeRemaining$, { initialValue: 0 });
@@ -98,8 +101,8 @@ export class LuxAppHeaderAcSessionTimerService {
         this.openDialog();
       }
 
-      // 1 Sekunde vor Ablauf damit der Dialog nicht geöffnet wird wenn keine Zeit gesetzt wurde
-      if (remainingMs / 1000 === 1) {
+      // ca. 1 Sekunde vor Ablauf damit der Dialog nicht geöffnet wird wenn keine Zeit gesetzt wurde
+      if (remainingMs / 1000 <= 1) {
         if (this.currentDialogRef) {
           this.currentDialogRef.closeDialog();
           this.currentDialogRef = null;

--- a/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
+++ b/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
@@ -45,10 +45,9 @@ export class LuxAppHeaderAcSessionTimerService {
   timeRemaining$ = toObservable(this.startingSeconds).pipe(
     switchMap((seconds) => {
       this.endTime = seconds > 0 ? Date.now() + seconds * 1000 : 0;
-
       return timer(0, 1000).pipe(
         map(() => Math.max(0, this.endTime - Date.now())),
-        takeWhile((remaining) => remaining > 0)
+        takeWhile((remaining) => remaining > 0, true)
       );
     })
   );
@@ -101,8 +100,8 @@ export class LuxAppHeaderAcSessionTimerService {
         this.openDialog();
       }
 
-      // ca. 1 Sekunde vor Ablauf damit der Dialog nicht geöffnet wird wenn keine Zeit gesetzt wurde
-      if (remainingMs / 1000 <= 1) {
+      // Timer ist natürlich abgelaufen (nicht durch explizites Zurücksetzen auf 0)
+      if (remainingMs <= 1000) {
         if (this.currentDialogRef) {
           this.currentDialogRef.closeDialog();
           this.currentDialogRef = null;

--- a/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
+++ b/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
@@ -46,8 +46,6 @@ export class LuxAppHeaderAcSessionTimerService {
     this.canExtendSessionValue = value;
   }
 
-
-
   // Observable for time remaining, based on synchronized endTime
   timeRemaining$ = toObservable(this.startingSeconds).pipe(
     switchMap((seconds) => {
@@ -131,7 +129,10 @@ export class LuxAppHeaderAcSessionTimerService {
     });
 
     // Listen for storage events to sync timer across tabs/apps using LuxStorageService observable
-    this.storageService.getItemAsObservable(LuxAppHeaderAcSessionTimerService.STORAGE_KEY)
+    this.storageService
+      .getItemAsObservable(
+        this.configService.currentConfig.sessionTimerConfig?.localStorageKeyName ?? LuxAppHeaderAcSessionTimerService.STORAGE_KEY
+      )
       .pipe(
         takeUntilDestroyed(),
         map((value) => (value ? parseInt(value, 10) : 0)),
@@ -230,7 +231,9 @@ export class LuxAppHeaderAcSessionTimerService {
    * Get the shared endTime from LuxStorageService
    */
   private getStoredEndTime(): number {
-    const value = this.storageService.getItem(LuxAppHeaderAcSessionTimerService.STORAGE_KEY);
+    const value = this.storageService.getItem(
+      this.configService.currentConfig.sessionTimerConfig?.localStorageKeyName ?? LuxAppHeaderAcSessionTimerService.STORAGE_KEY
+    );
     return value ? parseInt(value, 10) : 0;
   }
 
@@ -239,7 +242,11 @@ export class LuxAppHeaderAcSessionTimerService {
    */
   private setStoredEndTime(endTime: number) {
     if (endTime > 0) {
-      this.storageService.setItem(LuxAppHeaderAcSessionTimerService.STORAGE_KEY, endTime.toString(), false);
+      this.storageService.setItem(
+        this.configService.currentConfig.sessionTimerConfig?.localStorageKeyName ?? LuxAppHeaderAcSessionTimerService.STORAGE_KEY,
+        endTime.toString(),
+        false
+      );
     }
   }
 
@@ -247,6 +254,8 @@ export class LuxAppHeaderAcSessionTimerService {
    * Remove the shared endTime from LuxStorageService
    */
   private clearStoredEndTime() {
-    this.storageService.removeItem(LuxAppHeaderAcSessionTimerService.STORAGE_KEY);
+    this.storageService.removeItem(
+      this.configService.currentConfig.sessionTimerConfig?.localStorageKeyName ?? LuxAppHeaderAcSessionTimerService.STORAGE_KEY
+    );
   }
 }

--- a/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
+++ b/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer-service/lux-app-header-ac-session-timer.service.ts
@@ -1,9 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { computed, inject, Injectable, Signal, signal, EventEmitter } from '@angular/core';
+import { LuxStorageService } from '../../../../../lux-util/lux-storage.service';
 import { LuxDialogService } from '../../../../../lux-popups/lux-dialog/lux-dialog.service';
 import { LuxAppHeaderAcSessionTimerDialogComponent } from '../lux-app-header-ac-session-timer-dialog/lux-app-header-ac-session-timer-dialog';
 import { ILuxDialogConfig } from '../../../../../lux-popups/lux-dialog/lux-dialog-model/lux-dialog-config.interface';
-import { map, switchMap, takeWhile, timer } from 'rxjs';
+import { distinctUntilChanged, map, switchMap, takeWhile, timer } from 'rxjs';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { LuxComponentsConfigService } from '../../../../../lux-components-config/lux-components-config.service';
 
@@ -14,6 +15,9 @@ export class LuxAppHeaderAcSessionTimerService {
   private readonly http = inject(HttpClient);
   private readonly dialogService = inject(LuxDialogService);
   private readonly configService = inject(LuxComponentsConfigService);
+  private readonly storageService = inject(LuxStorageService);
+
+  private static readonly STORAGE_KEY = 'lux-components-session-endtime';
 
   luxLogoutEvent = new EventEmitter<void>();
   luxTimeoutEvent = new EventEmitter<void>();
@@ -42,11 +46,21 @@ export class LuxAppHeaderAcSessionTimerService {
     this.canExtendSessionValue = value;
   }
 
+
+
+  // Observable for time remaining, based on synchronized endTime
   timeRemaining$ = toObservable(this.startingSeconds).pipe(
     switchMap((seconds) => {
-      this.endTime = seconds > 0 ? Date.now() + seconds * 1000 : 0;
+      // Use endTime from LuxStorageService if available
+      const storedEndTime = this.getStoredEndTime();
+      if (storedEndTime && storedEndTime > Date.now()) {
+        this.endTime = storedEndTime;
+      } else {
+        this.endTime = seconds > 0 ? Date.now() + seconds * 1000 : 0;
+        this.setStoredEndTime(this.endTime);
+      }
       return timer(0, 1000).pipe(
-        map(() => Math.max(0, this.endTime - Date.now())),
+        map(() => Math.max(0, this.getStoredEndTime() - Date.now())),
         takeWhile((remaining) => remaining > 0, true)
       );
     })
@@ -116,6 +130,25 @@ export class LuxAppHeaderAcSessionTimerService {
       }
     });
 
+    // Listen for storage events to sync timer across tabs/apps using LuxStorageService observable
+    this.storageService.getItemAsObservable(LuxAppHeaderAcSessionTimerService.STORAGE_KEY)
+      .pipe(
+        takeUntilDestroyed(),
+        map((value) => (value ? parseInt(value, 10) : 0)),
+        distinctUntilChanged()
+      )
+      .subscribe((newEndTime) => {
+        if (newEndTime !== this.endTime) {
+          this.endTime = newEndTime;
+          const seconds = Math.max(0, Math.floor((this.endTime - Date.now()) / 1000));
+          this.startingSeconds.set(seconds);
+          // Nur Timeout auslösen wenn Zeit tatsächlich abgelaufen ist (nicht bei explizitem Reset auf 0 durch Logout)
+          if (newEndTime > 0 && newEndTime <= Date.now()) {
+            this.timeoutUser();
+          }
+        }
+      });
+
     this.url = this.configService.currentConfig.sessionTimerConfig?.url ?? '';
   }
 
@@ -124,7 +157,17 @@ export class LuxAppHeaderAcSessionTimerService {
       return;
     }
 
-    return this.http.post(this.url, null);
+    // On successful extension, update endTime in LuxStorageService
+    return this.http.post(this.url, null).pipe(
+      map((res) => {
+        const extensionSeconds = this.startingSeconds();
+        const newEndTime = Date.now() + extensionSeconds * 1000;
+        this.setStoredEndTime(newEndTime);
+        this.endTime = newEndTime;
+        this.startingSeconds.set(extensionSeconds);
+        return res;
+      })
+    );
   }
 
   openDialog() {
@@ -160,16 +203,50 @@ export class LuxAppHeaderAcSessionTimerService {
 
   timeoutUser() {
     this.resetTimer(0);
+    this.clearStoredEndTime();
     this.luxTimeoutEvent.emit();
   }
 
   logoutUser() {
     this.resetTimer(0);
+    this.clearStoredEndTime();
     this.luxLogoutEvent.emit();
   }
 
   resetTimer(seconds: number) {
     this.startingSeconds.set(0);
+    if (seconds > 0) {
+      const newEndTime = Date.now() + seconds * 1000;
+      this.setStoredEndTime(newEndTime);
+      this.endTime = newEndTime;
+    } else {
+      this.clearStoredEndTime();
+      this.endTime = 0;
+    }
     this.startingSeconds.set(seconds);
+  }
+
+  /**
+   * Get the shared endTime from LuxStorageService
+   */
+  private getStoredEndTime(): number {
+    const value = this.storageService.getItem(LuxAppHeaderAcSessionTimerService.STORAGE_KEY);
+    return value ? parseInt(value, 10) : 0;
+  }
+
+  /**
+   * Set the shared endTime in LuxStorageService
+   */
+  private setStoredEndTime(endTime: number) {
+    if (endTime > 0) {
+      this.storageService.setItem(LuxAppHeaderAcSessionTimerService.STORAGE_KEY, endTime.toString(), false);
+    }
+  }
+
+  /**
+   * Remove the shared endTime from LuxStorageService
+   */
+  private clearStoredEndTime() {
+    this.storageService.removeItem(LuxAppHeaderAcSessionTimerService.STORAGE_KEY);
   }
 }

--- a/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer.spec.ts
+++ b/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer.spec.ts
@@ -133,6 +133,7 @@ describe('LuxAppHeaderAcSessionTimerComponent', () => {
     });
 
     timerService.resetTimer(2);
+    tick(0); // Microtasks flushen → endTime = Date.now() + 2000, erste timer(0) Emission
     tick(1000); // 1s verbleibend → setTimeout(0) wird geplant
     tick(1); // setTimeout(0) feuert → timeoutUser()
 

--- a/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer.spec.ts
+++ b/projects/lux-components-lib/src/lib/lux-layout/lux-app-header-ac/lux-app-header-ac-subcomponents/lux-app-header-ac-session-timer/lux-app-header-ac-session-timer.spec.ts
@@ -8,12 +8,15 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideLuxTranslocoTesting } from '../../../../../testing/transloco-test.provider';
 
 describe('LuxAppHeaderAcSessionTimerComponent', () => {
+  const sessionTimerStorageKey = 'lux-components-session-endtime';
   let component: MockSessionTimerComponent;
   let fixture: ComponentFixture<MockSessionTimerComponent>;
   let timerService: LuxAppHeaderAcSessionTimerService;
   let httpController: HttpTestingController;
 
   beforeEach(waitForAsync(() => {
+    localStorage.removeItem(sessionTimerStorageKey);
+
     TestBed.configureTestingModule({
       imports: [MockSessionTimerComponent],
       providers: [
@@ -30,6 +33,10 @@ describe('LuxAppHeaderAcSessionTimerComponent', () => {
     httpController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   }));
+
+  afterEach(() => {
+    localStorage.removeItem(sessionTimerStorageKey);
+  });
 
   it('sollte erstellt werden', fakeAsync(() => {
     expect(component).toBeTruthy();

--- a/projects/lux-components-wiki/Versions/v21/lux‐session‐timer‐v21.md
+++ b/projects/lux-components-wiki/Versions/v21/lux‐session‐timer‐v21.md
@@ -15,7 +15,7 @@
 
 ## Overview / API
 
-Die `lux-app-header-ac-session-timer`-Komponente zeigt die verbleibende Zeit der aktuellen Session an, öffnet automatisch einen Dialog, wenn die Session abzulaufen droht, und ermöglicht die Verlängerung der Session. Der Timer wird nur angezeigt, wenn die verbleibende Zeit weniger als eine Stunde ist. Wenn die verbleibende Zeit weniger als eine Minute ist, werden die restlichen Sekunden angezeigt. Der Session Timer bekommt die Zeit über einen Interceptor. Dieser reagiert auf den Header `X-Session-Time` in HTTP-Antworten und setzt den Timer auf den angegebenen Wert (in Sekunden).
+Die `lux-app-header-ac-session-timer`-Komponente zeigt die verbleibende Zeit der aktuellen Session an, öffnet automatisch einen Dialog, wenn die Session abzulaufen droht, und ermöglicht die Verlängerung der Session. Der Timer wird nur angezeigt, wenn die verbleibende Zeit weniger als eine Stunde ist. Wenn die verbleibende Zeit weniger als eine Minute ist, werden die restlichen Sekunden angezeigt. Der Session-Timer erhält die Zeit über einen Interceptor. Dieser reagiert auf den Header `X-Session-Time` in HTTP-Antworten und setzt den Timer auf den angegebenen Wert (in Sekunden).
 
 ### Allgemein
 
@@ -34,7 +34,7 @@ Die `lux-app-header-ac-session-timer`-Komponente zeigt die verbleibende Zeit der
 
 ### Einwilligung
 
-Der Session Timer benutzt zur Berechnung der Restzeit den Local Storage. Dies MUSS in der Einwilligung der Seite erwähnt werden.
+Der Session-Timer verwendet zur Berechnung der Restzeit den Local Storage. Dies MUSS in der Einwilligungserklärung der Seite erwähnt werden.
 
 ```typescript
 export const appConsentProvider = {
@@ -66,6 +66,7 @@ const myConfiguration: LuxComponentsConfigParameters = {
     // Optional:
     httpSessionTimeHeaderName: 'X-GfI-Session-Time', // Der Name des HTTP-Headers, aus dem die Session-Zeit ausgelesen wird. 'X-GfI-Session-Time' wird standardmäßig verwendet, wenn der Name des Headers abweicht, muss dieser Parameter gesetzt werden.
     httpSessionProlongationHeaderName: 'X-GfI-Session-Prolongation' // Dieser HTTP-Header wird genutzt, um zu entscheiden, ob die Session verlängert werden darf. Standardmäßig wird der Header 'X-GfI-Session-Prolongation' genutzt, wenn ein anderer Header genutzt wird, muss der Parameter gesetzt werden.
+    localStorageKeyName: 'lux-components-session-endtime' // Der Timer speichert die Endzeit im LocalStorage. Der Name des Keys kann geändert werden, um Konflikte zwischen Anwendungen zu vermeiden. Standardmäßig wird 'lux-components-session-endtime' benutzt.
   }
 };
 

--- a/projects/lux-components-wiki/Versions/v21/lux‐session‐timer‐v21.md
+++ b/projects/lux-components-wiki/Versions/v21/lux‐session‐timer‐v21.md
@@ -7,8 +7,9 @@
     - [Allgemein](#allgemein)
     - [@Output](#output)
   - [Setup](#setup)
-    - [1. Konfiguration](#1-konfiguration)
-    - [2. Komponente einbinden](#2-komponente-einbinden)
+    - [Einwilligung](#einwilligung)
+    - [Konfiguration](#konfiguration)
+    - [Komponente einbinden](#komponente-einbinden)
   - [Beispiel](#beispiel)
     - [Vollständiges Beispiel](#vollständiges-beispiel)
 
@@ -31,7 +32,28 @@ Die `lux-app-header-ac-session-timer`-Komponente zeigt die verbleibende Zeit der
 
 ## Setup
 
-### 1. Konfiguration
+### Einwilligung
+
+Der Session Timer benutzt zur Berechnung der Restzeit den Local Storage. Dies MUSS in der Einwilligung der Seite erwähnt werden.
+
+```typescript
+export const appConsentProvider = {
+    //...
+    entries: [
+      {
+        type: LuxConsentStorageType.LocalStorage,
+        name: 'lux-components-session-endtime',
+        processingCountry: 'Deutschland',
+        purpose: LuxConsentPurpose.Essential,
+        duration: 'solange eine Sitzung aktiv ist',
+        description: 'Wird zur Speicherung der verbleibenden Sessiondauer benötigt. Es wird mit Sitzungsende gelöscht.'
+      }
+    ]
+  })
+};
+```
+
+### Konfiguration
 
 In der `app.config.ts` müssen die Endpunkte für den Session-Timer über den `LuxComponentsConfigModule` konfiguriert werden.
 
@@ -55,7 +77,7 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-### 2. Komponente einbinden
+### Komponente einbinden
 
 Die Komponente wird im Menü des App-Headers angezeigt.
 


### PR DESCRIPTION
### Problem #199 

Der Session Timer zählte die verbleibende Zeit anhand des Tick-Zählers eines RxJS `timer(0, 1000)` herunter `((seconds - n) * 1000)`. Browser drosseln Timer-Callbacks in inaktiven Tabs massiv (Chrome: ~1x/Minute, nach längerer Inaktivität gar nicht mehr). Dadurch verlangsamte sich der Countdown im Hintergrund-Tab oder fror vollständig ein – obwohl die Server-Session bereits abgelaufen war.

### Änderung

LuxAppHeaderAcSessionTimerService: Bei jedem Timer-Start wird ein Endzeitpunkt gespeichert (`endTime = Date.now() + seconds * 1000`). Jeder Tick berechnet die verbleibende Zeit als `Math.max(0, endTime - Date.now())`. Die Anzeige ist dadurch immer korrekt, unabhängig davon, ob Ticks verspätet oder gar nicht ausgelöst wurden.
