### PR TITLE
Issue #241: Tooltip-Unterstützung für `lux-select-ac` in Kombination …

### DIFF
--- a/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.html
+++ b/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.html
@@ -7,7 +7,7 @@
       <h3>Beispiel ohne Reactive-Form</h3>
       <lux-select-ac
         luxAutofocus
-        [luxOptionLabelProp]="useTemplatesForLabels ? undefined : 'label'"
+        luxOptionLabelProp="label"
         [luxOptions]="useSimpleArray ? optionsPrimitive : options"
         [luxLabel]="label"
         [luxHint]="hint"
@@ -33,15 +33,13 @@
         (luxFocusOut)="log(showOutputEvents, 'luxFocusOut', $event)"
         (luxSelectedChange)="log(showOutputEvents, 'luxSelectedChange', $event)"
         #defaultSelectComp
-      >
-        <ng-template let-item>via Template {{ item | json }}</ng-template>
-      </lux-select-ac>
+      ></lux-select-ac>
       <example-value [value]="value"></example-value>
     </div>
     <div class="lux-flex lux-flex-col">
       <h3>Beispiel mit Multiselect (ohne Reactive-Form)</h3>
       <lux-select-ac
-        [luxOptionLabelProp]="useTemplatesForLabels ? undefined : 'label'"
+        luxOptionLabelProp="label"
         [luxOptions]="useSimpleArray ? optionsPrimitive : options"
         [luxLabel]="label"
         [luxHint]="hint"
@@ -66,15 +64,13 @@
         (luxFocusIn)="log(showOutputEvents, 'luxFocusIn', $event)"
         (luxFocusOut)="log(showOutputEvents, 'luxFocusOut', $event)"
         #multiselectComp
-      >
-        <ng-template let-item>via Template {{ item | json }}</ng-template>
-      </lux-select-ac>
+      ></lux-select-ac>
       <example-value [value]="multiselectValue"></example-value>
     </div>
     <div class="lux-flex lux-flex-col" [formGroup]="form">
       <h3>Beispiel in Reactive-Form</h3>
       <lux-select-ac
-        [luxOptionLabelProp]="useTemplatesForLabels ? undefined : 'label'"
+        luxOptionLabelProp="label"
         [luxOptions]="useSimpleArray ? optionsPrimitive : options"
         [luxControlBinding]="controlBinding"
         [luxLabel]="label"
@@ -99,10 +95,29 @@
         (luxFocusOut)="log(showOutputEvents, 'luxFocusOut', $event)"
         (luxSelectedChange)="log(showOutputEvents, 'luxSelectedChange', $event)"
         #reactiveSelectComp
-      >
-        <ng-template let-item>via Template {{ item | json }}</ng-template>
-      </lux-select-ac>
+      ></lux-select-ac>
       <example-form-value [form]="form" [controlBinding]="controlBinding"></example-form-value>
+    </div>
+    <div class="lux-flex lux-flex-col">
+      <h3>Beispiel mit Options via ng-template (inkl. Tooltip)</h3>
+      <lux-select-ac
+        luxOptionLabelProp="label"
+        [luxOptions]="options"
+        luxLabel="Optionen via ng-template"
+        luxHint="Jede Option wird über ein ng-template gerendert und zeigt einen Tooltip. Der Filter lässt sich über die Optionen zuschalten."
+        [luxEnableFilter]="enableFilter"
+        [luxFilterPlaceholder]="filterPlaceholder"
+        [luxFilterValue]="filterValue"
+        [luxFilterClearAriaLabel]="filterClearAriaLabel"
+        [luxVisibleOptionCount]="visibleOptionCount"
+        [luxDense]="denseFormat"
+        [(luxSelected)]="templateValue"
+      >
+        <ng-template let-item>
+          <span [luxTooltip]="item.label">via Template {{ item | json }}</span>
+        </ng-template>
+      </lux-select-ac>
+      <example-value [value]="templateValue"></example-value>
     </div>
   </example-base-content>
   <example-base-simple-options class="lux-flex lux-flex-col lux-gap-4">
@@ -253,9 +268,6 @@
           <b>{{ compareWithFnString }}</b>
         </div>
       </lux-form-hint>
-    </lux-toggle-ac>
-    <lux-toggle-ac [(luxChecked)]="useTemplatesForLabels" luxLabel="Labels via Templates" [luxNoTopLabel]="true">
-      <lux-form-hint> Die Labels können über in die Component eingereichte Template-Tags erstellt werden. </lux-form-hint>
     </lux-toggle-ac>
     <lux-toggle-ac
       luxLabel="luxErrorMessage verwenden"

--- a/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.html
+++ b/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.html
@@ -105,6 +105,12 @@
         [luxOptions]="options"
         luxLabel="Optionen via ng-template"
         luxHint="Jede Option wird über ein ng-template gerendert und zeigt einen Tooltip. Der Filter lässt sich über die Optionen zuschalten."
+        [luxPlaceholder]="placeholder"
+        [luxRequired]="required"
+        [luxReadonly]="readonly"
+        [(luxDisabled)]="disabled"
+        [luxErrorMessage]="useErrorMessage ? errorMessage : undefined"
+        [luxErrorCallback]="useErrorMessage ? emptyCallback : errorCallback"
         [luxEnableFilter]="enableFilter"
         [luxFilterPlaceholder]="filterPlaceholder"
         [luxFilterValue]="filterValue"
@@ -112,6 +118,7 @@
         [luxVisibleOptionCount]="visibleOptionCount"
         [luxDense]="denseFormat"
         [(luxSelected)]="templateValue"
+        #tooltipSelectComp
       >
         <ng-template let-item>
           <span [luxTooltip]="item.label">via Template {{ item | json }}</span>
@@ -302,14 +309,14 @@
       <lux-button
         [luxStroked]="true"
         luxLabel="Werte resetten"
-        (luxClicked)="reset(defaultSelectComp, multiselectComp, reactiveSelectComp)"
+        (luxClicked)="reset(defaultSelectComp, multiselectComp, reactiveSelectComp, tooltipSelectComp)"
         class="lux-flex-none"
       >
       </lux-button>
       <lux-button
         [luxStroked]="true"
         luxLabel="Fehler anzeigen"
-        (luxClicked)="showErrors(defaultSelectComp, multiselectComp, reactiveSelectComp)"
+        (luxClicked)="showErrors(defaultSelectComp, multiselectComp, reactiveSelectComp, tooltipSelectComp)"
         class="lux-flex-none"
       >
       </lux-button>

--- a/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.ts
+++ b/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.ts
@@ -8,7 +8,8 @@ import {
   LuxFormSelectableBase,
   LuxInputAcComponent,
   LuxSelectAcComponent,
-  LuxToggleAcComponent
+  LuxToggleAcComponent,
+  LuxTooltipDirective
 } from '@ihk-gfi/lux-components';
 import { DemoMarkerType } from '../../base/status-marker/status-marker.model';
 import { StatusMarkerComponent } from '../../base/status-marker/status-marker.component';
@@ -52,14 +53,14 @@ interface SelectDummyForm {
     ExampleFormDisableComponent,
     ExampleBaseAdvancedOptionsComponent,
     ExampleBaseOptionsActionsComponent,
-    JsonPipe,
-    StatusMarkerComponent
+    LuxTooltipDirective,
+    StatusMarkerComponent,
+    JsonPipe
   ]
 })
 export class SelectAuthenticExampleComponent {
   readonly markerTypeNew = DemoMarkerType.New;
   useErrorMessage = true;
-  useTemplatesForLabels = false;
   useCompareWithFn = false;
   useValueFn = false;
   useSimpleArray = false;
@@ -131,6 +132,7 @@ export class SelectAuthenticExampleComponent {
   errorMessage = 'Das Feld enthält keinen gültigen Wert';
   value: any = null;
   multiselectValue: any = null;
+  templateValue: any = null;
   errorCallback = exampleErrorCallback;
   emptyCallback = emptyErrorCallback;
   pickValueFn = examplePickValueFn;

--- a/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.ts
+++ b/projects/demo-app/src/app/components-overview/select-authentic-example/select-authentic-example.component.ts
@@ -11,8 +11,8 @@ import {
   LuxToggleAcComponent,
   LuxTooltipDirective
 } from '@ihk-gfi/lux-components';
-import { DemoMarkerType } from '../../base/status-marker/status-marker.model';
 import { StatusMarkerComponent } from '../../base/status-marker/status-marker.component';
+import { DemoMarkerType } from '../../base/status-marker/status-marker.model';
 import { ExampleBaseContentComponent } from '../../example-base/example-base-root/example-base-subcomponents/example-base-content/example-base-content.component';
 import { ExampleBaseAdvancedOptionsComponent } from '../../example-base/example-base-root/example-base-subcomponents/example-base-options/example-base-advanced-options.component';
 import { ExampleBaseOptionsActionsComponent } from '../../example-base/example-base-root/example-base-subcomponents/example-base-options/example-base-options-actions.component';
@@ -155,6 +155,7 @@ export class SelectAuthenticExampleComponent {
   showErrors(...comps: LuxFormSelectableBase[]) {
     this.value = null;
     this.multiselectValue = null;
+    this.templateValue = null;
     this.form.get(this.controlBinding)!.setValue(null);
 
     this.changeRequired(true);
@@ -194,6 +195,7 @@ export class SelectAuthenticExampleComponent {
   reset(...comps: LuxFormSelectableBase[]) {
     this.value = undefined;
     this.multiselectValue = undefined;
+    this.templateValue = undefined;
     this.form.get(this.controlBinding)!.setValue(undefined);
 
     comps.forEach((comp: LuxFormSelectableBase) => {

--- a/projects/lux-components-lib/src/lib/lux-form/lux-select-ac/lux-select-ac.component.html
+++ b/projects/lux-components-lib/src/lib/lux-form/lux-select-ac/lux-select-ac.component.html
@@ -62,7 +62,7 @@
           [style.display]="!luxEnableFilter || selectFilter.isIndexVisible(i) ? '' : 'none'"
         >
           <ng-container
-            *ngTemplateOutlet="tempRef && !luxOptionLabelProp ? tempRef : noTemplateRefTemplate; context: { $implicit: luxOptions[i] }"
+            *ngTemplateOutlet="tempRef ? tempRef : noTemplateRefTemplate; context: { $implicit: luxOptions[i] }"
           ></ng-container>
         </mat-option>
       }

--- a/projects/lux-components-lib/src/lib/lux-form/lux-select-ac/lux-select-ac.component.spec.ts
+++ b/projects/lux-components-lib/src/lib/lux-form/lux-select-ac/lux-select-ac.component.spec.ts
@@ -847,6 +847,34 @@ describe('LuxSelectAcComponent', () => {
   });
 
   describe('mit aktivierter Filterfunktion', () => {
+    it('verwendet ng-template trotz gesetztem luxOptionLabelProp und filtert weiterhin korrekt', fakeAsync(() => {
+      const fixture = TestBed.createComponent(SelectFilterWithTemplateComponent);
+      fixture.detectChanges();
+
+      const trigger = fixture.debugElement.query(By.css('.mat-mdc-select-trigger')).nativeElement as HTMLElement;
+      trigger.click();
+      fixture.detectChanges();
+      flush();
+
+      const optionTexts = Array.from(
+        document.querySelectorAll('.mat-mdc-select-panel mat-option .mdc-list-item__primary-text') as NodeListOf<HTMLElement>
+      ).map((el) => el.textContent?.trim() ?? '');
+
+      expect(optionTexts.length).toBe(4);
+      expect(optionTexts[0]).toContain('OptionTpl: Meine Aufgaben');
+
+      const filterInput = document.querySelector('.lux-select-panel-filter-input') as HTMLInputElement;
+      filterInput.value = 'gruppe';
+      LuxTestHelper.dispatchFakeEvent(filterInput, 'input');
+      fixture.detectChanges();
+      flush();
+
+      const options = document.querySelectorAll('.mat-mdc-select-panel mat-option') as NodeListOf<HTMLElement>;
+      const visibleOptions = Array.from(options).filter((opt) => window.getComputedStyle(opt).display !== 'none');
+      expect(visibleOptions.length).toBe(1);
+      expect(visibleOptions[0].innerText.trim()).toContain('OptionTpl: Gruppenaufgaben');
+    }));
+
     it('rendert das Filterfeld nicht als deaktivierte mat-option', fakeAsync(() => {
       const fixture = TestBed.createComponent(SelectFilterComponent);
       fixture.detectChanges();
@@ -1057,7 +1085,10 @@ describe('LuxSelectAcComponent', () => {
       const filterInputAfterReopen = document.querySelector('.lux-select-panel-filter-input') as HTMLInputElement;
       filterInputAfterReopen.value = 'aufgaben';
       LuxTestHelper.dispatchFakeEvent(filterInputAfterReopen, 'input');
-      LuxTestHelper.dispatchEvent(filterInputAfterReopen, LuxTestHelper.createKeyboardEvent('keydown', 40, filterInputAfterReopen, 'ArrowDown'));
+      LuxTestHelper.dispatchEvent(
+        filterInputAfterReopen,
+        LuxTestHelper.createKeyboardEvent('keydown', 40, filterInputAfterReopen, 'ArrowDown')
+      );
       fixture.detectChanges();
       flush();
 
@@ -1454,6 +1485,24 @@ class SelectFilterComponent {
 
 @Component({
   template: `
+    <lux-select-ac [luxOptions]="options" luxOptionLabelProp="label" [luxEnableFilter]="true" [(luxSelected)]="selectedOption">
+      <ng-template let-option> {{ 'OptionTpl: ' + option.label }} </ng-template>
+    </lux-select-ac>
+  `,
+  imports: [LuxSelectAcComponent]
+})
+class SelectFilterWithTemplateComponent {
+  selectedOption: Option | null = null;
+  options: Option[] = [
+    { label: 'Meine Aufgaben', value: 'A' },
+    { label: 'Gruppenaufgaben', value: 'B' },
+    { label: 'Zurückgestellte Aufgaben', value: 'C' },
+    { label: 'Vertretungsaufgaben', value: 'D' }
+  ];
+}
+
+@Component({
+  template: `
     <form [formGroup]="formGroup">
       <lux-select-ac [luxOptions]="options" luxOptionLabelProp="label" luxControlBinding="task" [luxEnableFilter]="true"></lux-select-ac>
     </form>
@@ -1638,7 +1687,7 @@ class SelectMultiplePickValueFnComponent {
 
 @Component({
   template: `
-    <lux-select-ac [luxOptions]="options" [(luxSelected)]="selectedOption">
+    <lux-select-ac [luxOptions]="options" [luxOptionLabelProp]="labelProp" [(luxSelected)]="selectedOption">
       <ng-template let-option>
         {{ 'Option: ' + option.value }}
       </ng-template>

--- a/projects/lux-components-wiki/Versions/v21/lux‐select-v21.md
+++ b/projects/lux-components-wiki/Versions/v21/lux‐select-v21.md
@@ -243,3 +243,15 @@ Html
   [(luxSelected)]="selected"
 ></lux-select-ac>
 ```
+
+#### Mit ng-template, Tooltip und Filter
+
+Html
+
+```html
+<lux-select-ac [luxOptions]="options" luxOptionLabelProp="label" [luxEnableFilter]="true" [(luxSelected)]="selected">
+  <ng-template let-option>
+    <span [luxTooltip]="option.label">{{ option.label }}</span>
+  </ng-template>
+</lux-select-ac>
+```


### PR DESCRIPTION
…mit Filterfunktion hinzugefügt und Unit-Tests erweitert

#### Verhaltensänderung `lux-select-ac` (Template vs. `luxOptionLabelProp`)

Die Anzeige einer Option und die Ermittlung des Filter-/Default-Labels wurden entkoppelt. Ein projiziertes `<ng-template>` steuert jetzt **immer** die Anzeige unabhängig davon, ob `luxOptionLabelProp` gesetzt ist. `luxOptionLabelProp` steuert weiterhin das Default-Rendering (ohne Template) und das Filter-Label.

**Bedingung vorher:** `tempRef && !luxOptionLabelProp ? tempRef : default`
**Bedingung nachher:** `tempRef ? tempRef : default`

| # | `ng-template` | `luxOptionLabelProp` | Vorher | Nachher | Änderung |
|---|:---:|:---:|---|---|:---:|
| A | ❌ | ❌ | Default: `{{ option }}` | identisch | – |
| B | ❌ | ✅ | Default: `option[labelProp]` | identisch | – |
| C | ✅ | ❌ | Template rendert | identisch | – |
| D | ✅ | ✅ | Template **ignoriert** → `option[labelProp]` | Template **rendert** | ⚠️ geändert |

Nur **Fall D** ändert sich. Damit funktionieren Options-Tooltip (via Template) und
Filter (`luxEnableFilter`) endlich gleichzeitig.

**Einordnung:** faktisch ein Bugfix. `luxOptionLabelProp` war nie als „Template-Schalter" dokumentiert, und wer ein Template projiziert, erwartet dessen Anzeige, das alte D-Verhalten (Template wird stillschweigend unterdrückt) war eher unerwartet. Das Risiko für bestehenden Code ist entsprechend gering.