### PR TITLE
Issue #268: A11y - lux-menu-Items können per luxDisabledAria wahrnehmbar deaktiviert werden

### DIFF
--- a/projects/demo-app/src/app/components-overview/menu-example/menu-example.component.html
+++ b/projects/demo-app/src/app/components-overview/menu-example/menu-example.component.html
@@ -21,12 +21,14 @@
         [luxRaised]="item.raised"
         [luxColor]="item.color"
         [luxDisabled]="item.disabled"
+        [luxDisabledAria]="item.disabledAria ?? false"
         [luxLabel]="item.label"
         [luxButtonTooltip]="item.tooltip"
         [luxMenuTooltip]="item.tooltipMenu"
         [luxAlwaysVisible]="item.alwaysVisible"
         [luxTagId]="item.label"
         (luxClicked)="log(showOutputEvents, 'Item clicked', $event)"
+        (luxClickNotAllowed)="log(showOutputEvents, 'Item click not allowed (aria-disabled)', $event)"
         [luxRounded]="item.round"
         [luxHideLabelIfExtended]="item.hideLabelIfExtended"
         [luxHidden]="item.hidden"
@@ -273,6 +275,15 @@
             [luxNoTopLabel]="true"
           >
           </lux-toggle-ac>
+          <div class="lux-flex lux-items-center lux-gap-2">
+            <lux-toggle-ac class="lux-flex-auto" luxLabel="luxDisabledAria" [(luxChecked)]="item.disabledAria" [luxNoTopLabel]="true">
+              <lux-form-hint>
+                Über dieses Flag wird der Eintrag wahrnehmbar deaktiviert (aria-disabled): Er bleibt sichtbar und fokussierbar, die Aktion
+                wird aber nicht ausgeführt. Statt luxClicked wird luxClickNotAllowed emittiert (siehe Console-Log).
+              </lux-form-hint>
+            </lux-toggle-ac>
+            <app-status-marker [markerType]="markerTypeNew"></app-status-marker>
+          </div>
           <lux-toggle-ac
             luxLabel="luxHidden"
             luxHint="Über dieses Flag wird der Eintrag ausgeblendet."

--- a/projects/demo-app/src/app/components-overview/menu-example/menu-example.component.ts
+++ b/projects/demo-app/src/app/components-overview/menu-example/menu-example.component.ts
@@ -381,6 +381,7 @@ interface ExampleMenuItem {
   raised: boolean;
   color: LuxThemePalette;
   disabled: boolean;
+  disabledAria?: boolean;
   hidden: boolean;
   label: string;
   tooltip: string;

--- a/projects/lux-components-lib/CHANGELOG.md
+++ b/projects/lux-components-lib/CHANGELOG.md
@@ -1,38 +1,40 @@
 # Changelog
 
 - [Changelog](#changelog)
-  - [Version 21.7.0](#version-2170)
+  - [Version 21.8.0](#version-2180)
     - [Issues](#issues)
-  - [Version 21.6.0](#version-2160)
+  - [Version 21.7.0](#version-2170)
     - [Issues](#issues-1)
-  - [Version 21.5.0](#version-2150)
+  - [Version 21.6.0](#version-2160)
     - [Issues](#issues-2)
-  - [Version 21.4.0](#version-2140)
+  - [Version 21.5.0](#version-2150)
     - [Issues](#issues-3)
-  - [Version 21.3.1](#version-2131)
+  - [Version 21.4.0](#version-2140)
     - [Issues](#issues-4)
-  - [Version 21.3.0](#version-2130)
+  - [Version 21.3.1](#version-2131)
     - [Issues](#issues-5)
-  - [Version 21.2.0](#version-2120)
+  - [Version 21.3.0](#version-2130)
     - [Issues](#issues-6)
-  - [Version 21.1.0](#version-2110)
+  - [Version 21.2.0](#version-2120)
     - [Issues](#issues-7)
-  - [Version 21.0.0](#version-2100)
+  - [Version 21.1.0](#version-2110)
     - [Issues](#issues-8)
-  - [Version 19.7.0](#version-1970)
+  - [Version 21.0.0](#version-2100)
     - [Issues](#issues-9)
-  - [Version 19.6.0](#version-1960)
+  - [Version 19.7.0](#version-1970)
     - [Issues](#issues-10)
-  - [Version 19.5.0](#version-1950)
+  - [Version 19.6.0](#version-1960)
     - [Issues](#issues-11)
-  - [Version 19.4.0](#version-1940)
+  - [Version 19.5.0](#version-1950)
     - [Issues](#issues-12)
-  - [Version 19.3.0](#version-1930)
+  - [Version 19.4.0](#version-1940)
     - [Issues](#issues-13)
-  - [Version 19.2.0](#version-1920)
+  - [Version 19.3.0](#version-1930)
     - [Issues](#issues-14)
-  - [Version 19.1.0](#version-1910)
+  - [Version 19.2.0](#version-1920)
     - [Issues](#issues-15)
+  - [Version 19.1.0](#version-1910)
+    - [Issues](#issues-16)
   - [Version 19.0.0](#version-1900)
     - [Technische Änderungen](#technische-änderungen)
       - [Umstellung auf Standalone-Components](#umstellung-auf-standalone-components)
@@ -40,7 +42,13 @@
       - [lux-file-list ist deprecated](#lux-file-list-ist-deprecated)
     - [Optische Änderungen](#optische-änderungen)
     - [Allgemein](#allgemein)
-    - [Issues](#issues-16)
+    - [Issues](#issues-17)
+
+## Version 21.8.0
+
+### Issues
+
+- Issue #268: lux-menu-Items können per luxDisabledAria wahrnehmbar deaktiviert werden (sichtbar, fokussierbar, Screenreader sagen "deaktiviert" an); Klick/Enter emittiert luxClickNotAllowed statt luxClicked. Bewusst ohne Styling: aria-disabled Items sehen wie normale Items aus, die Anwendung reagiert über luxClickNotAllowed. Abgrenzung: luxDisabled (aus der Tastaturreihenfolge entfernt) vs. luxDisabledAria (wahrnehmbar deaktiviert) vs. luxHidden (ausgeblendet). Neu dafür: Direktive luxAriaDisabled, die aria-disabled zuverlässig auch an Material-Elementen setzt.
 
 ## Version 21.7.0
 
@@ -152,7 +160,7 @@
 - Issue #134: Erweiterung Button-Komponente: luxDisabledAria & ClickNotAllowed Event (#145)
 - Issue #137: Umstellung auf Angular v21 (#147)
 - Issue #157: Finalisierung Release v21: Bugfixes, Dokumentation, Updater,... (#160)
-    - [Issues](#issues-7)
+    - [Issues](#issues-8)
 
 ## Version 19.7.0
 

--- a/projects/lux-components-lib/src/lib/lux-action/lux-action-model/lux-action-component-base.class.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-action-model/lux-action-component-base.class.ts
@@ -15,6 +15,15 @@ export class LuxActionComponentBaseClass {
   @Input() luxIconShowRight? = false;
   @Input() luxTagId?: string;
   @Input() luxDisabled? = false;
+  /**
+   * Markiert die Action als wahrnehmbar deaktiviert (aria-disabled): sichtbar und
+   * fokussierbar, Screenreader sagen "deaktiviert" an, die Aktion wird aber nicht
+   * ausgeführt. Statt luxClicked wird luxClickNotAllowed emittiert. Bewusst ohne
+   * eigenes Styling, die Anwendung reagiert über luxClickNotAllowed.
+   * Abgrenzung: luxDisabled entfernt die Action aus der Tastaturreihenfolge,
+   * luxHidden blendet sie komplett aus.
+   */
+  @Input() luxDisabledAria? = false;
   @Input() luxRounded? = false;
   @Input() luxFlat? = false;
   @Input() luxStroked? = false;

--- a/projects/lux-components-lib/src/lib/lux-action/lux-action-model/lux-action-component-base.class.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-action-model/lux-action-component-base.class.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Input, Output } from '@angular/core';
+import { Directive, EventEmitter, Input, input, Output } from '@angular/core';
 import { LuxThemePalette } from '../../lux-util/lux-colors.enum';
 
 /**
@@ -25,7 +25,7 @@ export class LuxActionComponentBaseClass {
    * Hinweis: Wird derzeit von lux-button und lux-menu-item umgesetzt;
    * lux-link und lux-link-plain werten dieses Flag noch nicht aus.
    */
-  @Input() luxDisabledAria? = false;
+  luxDisabledAria = input<boolean | undefined>(false);
   @Input() luxRounded? = false;
   @Input() luxFlat? = false;
   @Input() luxStroked? = false;

--- a/projects/lux-components-lib/src/lib/lux-action/lux-action-model/lux-action-component-base.class.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-action-model/lux-action-component-base.class.ts
@@ -22,6 +22,8 @@ export class LuxActionComponentBaseClass {
    * eigenes Styling, die Anwendung reagiert über luxClickNotAllowed.
    * Abgrenzung: luxDisabled entfernt die Action aus der Tastaturreihenfolge,
    * luxHidden blendet sie komplett aus.
+   * Hinweis: Wird derzeit von lux-button und lux-menu-item umgesetzt;
+   * lux-link und lux-link-plain werten dieses Flag noch nicht aus.
    */
   @Input() luxDisabledAria? = false;
   @Input() luxRounded? = false;

--- a/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.html
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.html
@@ -15,7 +15,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName, 'lux-button-spinner': luxLoading }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
+    [luxAriaDisabled]="luxDisabledAria() ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>
@@ -36,7 +36,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
+    [luxAriaDisabled]="luxDisabledAria() ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>
@@ -57,7 +57,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
+    [luxAriaDisabled]="luxDisabledAria() ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>
@@ -77,7 +77,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': true, 'lux-button-spinner': luxLoading }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
+    [luxAriaDisabled]="luxDisabledAria() ? 'true' : undefined"
   >
     @if (luxLoading && !luxDisabled) {
       <lux-progress
@@ -110,7 +110,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName, 'lux-fab-rounded-default': !luxColor }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
+    [luxAriaDisabled]="luxDisabledAria() ? 'true' : undefined"
   >
     @if (luxLoading && !luxDisabled) {
       <lux-progress
@@ -143,7 +143,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName, 'lux-fab-stroked-default': !luxColor }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
+    [luxAriaDisabled]="luxDisabledAria() ? 'true' : undefined"
   >
     @if (luxLoading && !luxDisabled) {
       <lux-progress
@@ -177,7 +177,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
+    [luxAriaDisabled]="luxDisabledAria() ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>

--- a/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.html
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.html
@@ -15,7 +15,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName, 'lux-button-spinner': luxLoading }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [attr.aria-disabled]="luxDisabledAria ? 'true' : null"
+    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>
@@ -36,7 +36,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [attr.aria-disabled]="luxDisabledAria ? 'true' : null"
+    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>
@@ -57,7 +57,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [attr.aria-disabled]="luxDisabledAria ? 'true' : null"
+    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>
@@ -77,7 +77,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': true, 'lux-button-spinner': luxLoading }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [attr.aria-disabled]="luxDisabledAria ? 'true' : null"
+    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
   >
     @if (luxLoading && !luxDisabled) {
       <lux-progress
@@ -110,7 +110,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName, 'lux-fab-rounded-default': !luxColor }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [attr.aria-disabled]="luxDisabledAria ? 'true' : null"
+    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
   >
     @if (luxLoading && !luxDisabled) {
       <lux-progress
@@ -143,7 +143,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName, 'lux-fab-stroked-default': !luxColor }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [attr.aria-disabled]="luxDisabledAria ? 'true' : null"
+    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
   >
     @if (luxLoading && !luxDisabled) {
       <lux-progress
@@ -177,7 +177,7 @@
     [luxTagId]="luxTagId"
     [ngClass]="{ 'lux-icon-button': !!luxIconName }"
     [attr.aria-label]="luxLabel ? luxLabel : ''"
-    [attr.aria-disabled]="luxDisabledAria ? 'true' : null"
+    [luxAriaDisabled]="luxDisabledAria ? 'true' : undefined"
   >
     <ng-container *ngTemplateOutlet="luxButtonContent"></ng-container>
   </button>

--- a/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.spec.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.spec.ts
@@ -178,6 +178,17 @@ describe('LuxButtonComponent', () => {
       expect(buttonEl.nativeElement.getAttribute('aria-disabled')).toBe('true');
     }));
 
+    it('setzt aria-disabled auch bei initial aktivem luxDisabledAria', fakeAsync(() => {
+      // Regression: Das MatButton-Host-Binding für aria-disabled hat einen initial
+      // gesetzten Wert im ersten Change-Detection-Zyklus wieder entfernt.
+      const initialFixture = TestBed.createComponent(MockButtonComponent);
+      initialFixture.componentInstance.disabledAria = true;
+      initialFixture.detectChanges();
+
+      const buttonEl = initialFixture.debugElement.query(By.css('button'));
+      expect(buttonEl.nativeElement.getAttribute('aria-disabled')).toBe('true');
+    }));
+
     it('emittiert luxClickNotAllowed und kein luxClicked', fakeAsync(() => {
       const onClickSpy = spyOn(fixture.componentInstance, 'onClick');
       const onClickNotAllowedSpy = spyOn(fixture.componentInstance, 'onClickNotAllowed');

--- a/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.ts
@@ -46,7 +46,6 @@ export class LuxButtonComponent extends LuxActionComponentBaseClass implements O
   @Input() luxSpinnerMode: LuxProgressModeType = 'indeterminate';
   @Input() luxSpinnerValue = 70;
   @Input() luxLoading = false;
-  @Input() luxDisabledAria = false;
   @Input() luxIconButton = false;
 
   @Output() luxAuxClicked = new EventEmitter<Event>();

--- a/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.ts
@@ -5,6 +5,7 @@ import { Subject, Subscription } from 'rxjs';
 import { throttleTime } from 'rxjs/operators';
 import { LuxProgressComponent, LuxProgressModeType } from '../../lux-common/lux-progress/lux-progress.component';
 import { LuxComponentsConfigService } from '../../lux-components-config/lux-components-config.service';
+import { LuxAriaDisabledDirective } from '../../lux-directives/lux-aria/lux-aria-disabled.directive';
 import { LuxTagIdDirective } from '../../lux-directives/lux-tag-id/lux-tag-id.directive';
 import { LuxTooltipDirective } from '../../lux-directives/lux-tooltip/lux-tooltip.directive';
 import { LuxIconComponent } from '../../lux-icon/lux-icon/lux-icon.component';
@@ -15,7 +16,7 @@ import { LuxActionComponentBaseClass } from '../lux-action-model/lux-action-comp
   selector: 'lux-button',
   templateUrl: './lux-button.component.html',
   styleUrls: ['./lux-button.component.scss'],
-  imports: [MatButton, LuxTagIdDirective, NgClass, NgTemplateOutlet, MatFabButton, MatIconButton, LuxIconComponent, LuxProgressComponent],
+  imports: [MatButton, LuxAriaDisabledDirective, LuxTagIdDirective, NgClass, NgTemplateOutlet, MatFabButton, MatIconButton, LuxIconComponent, LuxProgressComponent],
   host: {
     '[class.lux-flat]': 'luxFlat',
     '[class.lux-raised]': 'luxRaised',

--- a/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-button/lux-button.component.ts
@@ -142,7 +142,7 @@ export class LuxButtonComponent extends LuxActionComponentBaseClass implements O
   }
 
   private shouldHandleNotAllowedClick(): boolean {
-    return !!this.luxDisabledAria && !this.luxDisabled;
+    return !!this.luxDisabledAria() && !this.luxDisabled;
   }
 
   private emitClickNotAllowed(event: MouseEvent) {

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu-subcomponents/lux-menu-item.component.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu-subcomponents/lux-menu-item.component.ts
@@ -15,6 +15,7 @@ export class LuxMenuItemComponent extends LuxActionComponentBaseClass {
   luxMenuItemSubtitle = input<string>('');
   luxMenuItemSelected = input<boolean>(false);
 
+  @Output() luxClickNotAllowed = new EventEmitter<Event>();
   @Output() luxHiddenChange = new EventEmitter<boolean>();
   @Output() luxHideLabelIfExtendedChange = new EventEmitter<boolean>();
   @Output() luxAlwaysVisibleChange = new EventEmitter<boolean>();
@@ -66,5 +67,9 @@ export class LuxMenuItemComponent extends LuxActionComponentBaseClass {
 
   clicked(event: Event) {
     this.luxClicked.emit(event);
+  }
+
+  clickNotAllowed(event: Event) {
+    this.luxClickNotAllowed.emit(event);
   }
 }

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu-subcomponents/lux-menu-item.component.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu-subcomponents/lux-menu-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, input, Input, Output } from '@angular/core';
+import { Component, EventEmitter, input, Input, Output, output } from '@angular/core';
 import { LuxThemePalette } from '../../../lux-util/lux-colors.enum';
 import { LuxActionComponentBaseClass } from '../../lux-action-model/lux-action-component-base.class';
 
@@ -15,7 +15,7 @@ export class LuxMenuItemComponent extends LuxActionComponentBaseClass {
   luxMenuItemSubtitle = input<string>('');
   luxMenuItemSelected = input<boolean>(false);
 
-  @Output() luxClickNotAllowed = new EventEmitter<Event>();
+  luxClickNotAllowed = output<Event>();
   @Output() luxHiddenChange = new EventEmitter<boolean>();
   @Output() luxHideLabelIfExtendedChange = new EventEmitter<boolean>();
   @Output() luxAlwaysVisibleChange = new EventEmitter<boolean>();

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.html
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.html
@@ -14,7 +14,7 @@
         [luxStroked]="menuItem.luxStroked"
         [luxIconName]="menuItem.luxIconName"
         [luxDisabled]="menuItem.luxDisabled"
-        [luxDisabledAria]="menuItem.luxDisabledAria"
+        [luxDisabledAria]="menuItem.luxDisabledAria()"
         [luxTagId]="menuItem.luxTagId"
         [luxRounded]="menuItem.luxRounded"
         [luxButtonBadge]="menuItem.luxButtonBadge"
@@ -60,7 +60,7 @@
           [class.with-badge]="menuItem.luxButtonBadge"
           [luxTooltip]="menuItem.luxMenuTooltip"
           [disabled]="menuItem.luxDisabled"
-          [luxAriaDisabled]="menuItem.luxDisabledAria ? 'true' : undefined"
+          [luxAriaDisabled]="menuItem.luxDisabledAria() ? 'true' : undefined"
           luxTagIdHandler
           [luxTagIdStartElement]="elementRef.nativeElement"
           [luxTagIdTargetSelf]="true"
@@ -133,7 +133,7 @@
             [class.with-badge]="menuItem.luxButtonBadge"
             [luxTooltip]="menuItem.luxMenuTooltip"
             [disabled]="menuItem.luxDisabled"
-            [luxAriaDisabled]="menuItem.luxDisabledAria ? 'true' : undefined"
+            [luxAriaDisabled]="menuItem.luxDisabledAria() ? 'true' : undefined"
             [ngClass]="
               (menuItem.luxClass ?? '') +
               (menuItem.luxMenuItemSelected() && !menuItem.luxDisabled ? ' lux-menu-item-selected' : '') +
@@ -198,7 +198,7 @@
             [class.with-badge]="menuItem.luxButtonBadge"
             [luxTooltip]="menuItem.luxMenuTooltip"
             [disabled]="menuItem.luxDisabled"
-            [luxAriaDisabled]="menuItem.luxDisabledAria ? 'true' : undefined"
+            [luxAriaDisabled]="menuItem.luxDisabledAria() ? 'true' : undefined"
             luxTagIdHandler
             [luxTagIdStartElement]="elementRef.nativeElement"
             [luxTagIdTargetSelf]="true"

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.html
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.html
@@ -14,11 +14,13 @@
         [luxStroked]="menuItem.luxStroked"
         [luxIconName]="menuItem.luxIconName"
         [luxDisabled]="menuItem.luxDisabled"
+        [luxDisabledAria]="menuItem.luxDisabledAria"
         [luxTagId]="menuItem.luxTagId"
         [luxRounded]="menuItem.luxRounded"
         [luxButtonBadge]="menuItem.luxButtonBadge"
         [luxButtonBadgeColor]="menuItem.luxButtonBadgeColor"
         (luxClicked)="menuItemClicked(menuItem, $event)"
+        (luxClickNotAllowed)="menuItem.clickNotAllowed($event)"
         luxAriaLabel="{{ menuItem.luxLabel }}"
         luxAriaLabelSelector="button"
         luxTabIndex="0"
@@ -58,6 +60,7 @@
           [class.with-badge]="menuItem.luxButtonBadge"
           [luxTooltip]="menuItem.luxMenuTooltip"
           [disabled]="menuItem.luxDisabled"
+          [luxAriaDisabled]="menuItem.luxDisabledAria ? 'true' : undefined"
           luxTagIdHandler
           [luxTagIdStartElement]="elementRef.nativeElement"
           [luxTagIdTargetSelf]="true"
@@ -130,6 +133,7 @@
             [class.with-badge]="menuItem.luxButtonBadge"
             [luxTooltip]="menuItem.luxMenuTooltip"
             [disabled]="menuItem.luxDisabled"
+            [luxAriaDisabled]="menuItem.luxDisabledAria ? 'true' : undefined"
             [ngClass]="
               (menuItem.luxClass ?? '') +
               (menuItem.luxMenuItemSelected() && !menuItem.luxDisabled ? ' lux-menu-item-selected' : '') +
@@ -194,6 +198,7 @@
             [class.with-badge]="menuItem.luxButtonBadge"
             [luxTooltip]="menuItem.luxMenuTooltip"
             [disabled]="menuItem.luxDisabled"
+            [luxAriaDisabled]="menuItem.luxDisabledAria ? 'true' : undefined"
             luxTagIdHandler
             [luxTagIdStartElement]="elementRef.nativeElement"
             [luxTagIdTargetSelf]="true"

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.spec.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.spec.ts
@@ -269,6 +269,109 @@ describe('LuxMenuComponent', () => {
     discardPeriodicTasks();
   }));
 
+  describe('Attribut "luxDisabledAria"', () => {
+    it('Sollte sichtbare Buttons als aria-disabled markieren (kein natives disabled)', fakeAsync(() => {
+      // Vorbedingungen prüfen
+      component.generateItems(3);
+      component.items[0].disabledAria = true;
+      updateExtendedMenuItems();
+
+      // Nachbedingungen prüfen
+      const ariaDisabledButtons = fixture.debugElement.queryAll(By.css('.lux-menu-item:not(.lux-hidden) button[aria-disabled="true"]'));
+      expect(ariaDisabledButtons.length).toBe(1);
+      expect(ariaDisabledButtons[0].nativeElement.hasAttribute('disabled')).toBeFalse();
+    }));
+
+    it('Sollte bei sichtbaren Buttons luxClickNotAllowed statt luxClicked emittieren', fakeAsync(() => {
+      // Vorbedingungen prüfen
+      const clickedSpy = spyOn(component, 'clicked');
+      const notAllowedSpy = spyOn(component, 'clickNotAllowed');
+      component.generateItems(1);
+      component.items[0].disabledAria = true;
+      updateExtendedMenuItems();
+
+      // Änderungen durchführen
+      const buttonEl = fixture.debugElement.query(By.css('.lux-menu-item:not(.lux-hidden) button'));
+      buttonEl.nativeElement.click();
+      LuxTestHelper.wait(fixture);
+
+      // Nachbedingungen prüfen
+      expect(notAllowedSpy).toHaveBeenCalledTimes(1);
+      expect(clickedSpy).not.toHaveBeenCalled();
+    }));
+
+    it('Sollte Panel-Items als aria-disabled markieren, ohne natives disabled (bleiben fokussierbar)', fakeAsync(() => {
+      // Vorbedingungen prüfen
+      component.generateItems(3);
+      component.displayExtended = false;
+      component.items[1].disabledAria = true;
+      LuxTestHelper.wait(fixture);
+
+      // Änderungen durchführen
+      menuComponent.menuTriggerElRef!.nativeElement.click();
+      LuxTestHelper.wait(fixture);
+
+      // Nachbedingungen prüfen
+      const overlayEl = overlayContainer.getContainerElement();
+      const ariaDisabledItems = overlayEl.querySelectorAll('button.lux-menu-item[aria-disabled="true"]');
+      expect(ariaDisabledItems.length).toBe(1);
+      // Kein natives disabled: Item bleibt fokussierbar und wird von der
+      // Pfeiltasten-Navigation des mat-menu nicht übersprungen.
+      expect(ariaDisabledItems[0].hasAttribute('disabled')).toBeFalse();
+
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('Sollte bei Panel-Items luxClickNotAllowed statt luxClicked emittieren', fakeAsync(() => {
+      // Vorbedingungen prüfen
+      const clickedSpy = spyOn(component, 'clicked');
+      const notAllowedSpy = spyOn(component, 'clickNotAllowed');
+      component.generateItems(2);
+      component.displayExtended = false;
+      component.items[0].disabledAria = true;
+      LuxTestHelper.wait(fixture);
+
+      // Änderungen durchführen
+      menuComponent.menuTriggerElRef!.nativeElement.click();
+      LuxTestHelper.wait(fixture);
+
+      const overlayEl = overlayContainer.getContainerElement();
+      const ariaDisabledItem = overlayEl.querySelector('button.lux-menu-item[aria-disabled="true"]') as HTMLElement;
+      ariaDisabledItem.click();
+      LuxTestHelper.wait(fixture);
+
+      // Nachbedingungen prüfen
+      expect(notAllowedSpy).toHaveBeenCalledTimes(1);
+      expect(clickedSpy).not.toHaveBeenCalled();
+
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('Sollte luxDisabled unverändert lassen (natives disabled, kein luxClickNotAllowed)', fakeAsync(() => {
+      // Vorbedingungen prüfen
+      const notAllowedSpy = spyOn(component, 'clickNotAllowed');
+      component.generateItems(2);
+      component.displayExtended = false;
+      component.items[0].disabled = true;
+      LuxTestHelper.wait(fixture);
+
+      // Änderungen durchführen
+      menuComponent.menuTriggerElRef!.nativeElement.click();
+      LuxTestHelper.wait(fixture);
+
+      // Nachbedingungen prüfen
+      const overlayEl = overlayContainer.getContainerElement();
+      const disabledItems = overlayEl.querySelectorAll('button.lux-menu-item[disabled]');
+      expect(disabledItems.length).toBe(1);
+      expect(notAllowedSpy).not.toHaveBeenCalled();
+
+      flush();
+      discardPeriodicTasks();
+    }));
+  });
+
   const updateExtendedMenuItems = () => {
     LuxTestHelper.wait(fixture);
     menuComponent.updateExtendedMenuItems();
@@ -292,9 +395,11 @@ describe('LuxMenuComponent', () => {
         [luxTagId]="item.label"
         [luxAlwaysVisible]="item.alwaysVisible"
         [luxDisabled]="item.disabled"
+        [luxDisabledAria]="item.disabledAria"
         [luxRaised]="item.raised"
         [luxColor]="item.color"
         (luxClicked)="clicked()"
+        (luxClickNotAllowed)="clickNotAllowed()"
       >
       </lux-menu-item>
     }
@@ -320,11 +425,14 @@ class MockComponent {
     tagId: string;
     alwaysVisible: boolean;
     disabled: boolean;
+    disabledAria: boolean;
     raised?: boolean;
     color: LuxThemePalette;
   }[] = [];
 
   clicked() {}
+
+  clickNotAllowed() {}
 
   closed() {}
 
@@ -341,6 +449,7 @@ class MockComponent {
         tagId: 'TagId ' + (start + i),
         alwaysVisible: false,
         disabled: false,
+        disabledAria: false,
         color: 'primary'
       });
     }

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.spec.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.spec.ts
@@ -349,6 +349,67 @@ describe('LuxMenuComponent', () => {
       discardPeriodicTasks();
     }));
 
+    it('Sollte aria-disabled behalten, wenn luxDisabled zur Laufzeit von true auf false wechselt', fakeAsync(() => {
+      // Regression: Das MatMenuItem-Host-Binding (aria-disabled = disabled) schreibt das
+      // Attribut bei einer eigenen Wertänderung neu und würde den Direktiven-Wert überschreiben.
+      component.generateItems(2);
+      component.displayExtended = false;
+      component.items[0].disabledAria = true;
+      component.items[0].disabled = true;
+      LuxTestHelper.wait(fixture);
+
+      menuComponent.menuTriggerElRef!.nativeElement.click();
+      LuxTestHelper.wait(fixture);
+
+      component.items[0].disabled = false;
+      LuxTestHelper.wait(fixture);
+
+      const overlayEl = overlayContainer.getContainerElement();
+      const ariaDisabledItems = overlayEl.querySelectorAll('button.lux-menu-item[aria-disabled="true"]');
+      expect(ariaDisabledItems.length).toBe(1);
+      expect(ariaDisabledItems[0].hasAttribute('disabled')).toBeFalse();
+
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('Sollte aria-disabled entfernen, wenn luxDisabledAria zurückgesetzt wird', fakeAsync(() => {
+      component.generateItems(2);
+      component.displayExtended = false;
+      component.items[0].disabledAria = true;
+      LuxTestHelper.wait(fixture);
+
+      menuComponent.menuTriggerElRef!.nativeElement.click();
+      LuxTestHelper.wait(fixture);
+
+      component.items[0].disabledAria = false;
+      LuxTestHelper.wait(fixture);
+
+      const overlayEl = overlayContainer.getContainerElement();
+      expect(overlayEl.querySelectorAll('button.lux-menu-item[aria-disabled="true"]').length).toBe(0);
+
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('Sollte luxHidden unverändert lassen (verstecktes Item erscheint trotz luxDisabledAria nicht im Panel)', fakeAsync(() => {
+      component.generateItems(2);
+      component.displayExtended = false;
+      component.items[0].disabledAria = true;
+      component.items[0].hidden = true;
+      LuxTestHelper.wait(fixture);
+
+      menuComponent.menuTriggerElRef!.nativeElement.click();
+      LuxTestHelper.wait(fixture);
+
+      const overlayEl = overlayContainer.getContainerElement();
+      expect(overlayEl.querySelectorAll('button.lux-menu-item').length).toBe(1);
+      expect(overlayEl.querySelectorAll('button.lux-menu-item[aria-disabled="true"]').length).toBe(0);
+
+      flush();
+      discardPeriodicTasks();
+    }));
+
     it('Sollte luxDisabled unverändert lassen (natives disabled, kein luxClickNotAllowed)', fakeAsync(() => {
       // Vorbedingungen prüfen
       const notAllowedSpy = spyOn(component, 'clickNotAllowed');
@@ -396,6 +457,7 @@ describe('LuxMenuComponent', () => {
         [luxAlwaysVisible]="item.alwaysVisible"
         [luxDisabled]="item.disabled"
         [luxDisabledAria]="item.disabledAria"
+        [luxHidden]="item.hidden"
         [luxRaised]="item.raised"
         [luxColor]="item.color"
         (luxClicked)="clicked()"
@@ -426,6 +488,7 @@ class MockComponent {
     alwaysVisible: boolean;
     disabled: boolean;
     disabledAria: boolean;
+    hidden: boolean;
     raised?: boolean;
     color: LuxThemePalette;
   }[] = [];
@@ -450,6 +513,7 @@ class MockComponent {
         alwaysVisible: false,
         disabled: false,
         disabledAria: false,
+        hidden: false,
         color: 'primary'
       });
     }

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.ts
@@ -291,7 +291,7 @@ export class LuxMenuComponent implements AfterViewInit, AfterContentInit, AfterV
   menuItemClicked(menuItem: LuxMenuItemComponent, event: Event) {
     // aria-disabled Items führen die Aktion nicht aus, bleiben aber sichtbar und
     // fokussierbar. Analog zum LuxButton wird stattdessen luxClickNotAllowed emittiert.
-    if (menuItem.luxDisabledAria && !menuItem.luxDisabled) {
+    if (menuItem.luxDisabledAria() && !menuItem.luxDisabled) {
       event.preventDefault();
       event.stopImmediatePropagation();
       menuItem.clickNotAllowed(event);

--- a/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.ts
+++ b/projects/lux-components-lib/src/lib/lux-action/lux-menu/lux-menu.component.ts
@@ -23,6 +23,7 @@ import { MatDivider } from '@angular/material/divider';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { Subscription } from 'rxjs';
+import { LuxAriaDisabledDirective } from '../../lux-directives/lux-aria/lux-aria-disabled.directive';
 import { LuxAriaLabelDirective } from '../../lux-directives/lux-aria/lux-aria-label.directive';
 import { LuxTabIndexDirective } from '../../lux-directives/lux-tabindex/lux-tab-index.directive';
 import { LuxTagIdDirective } from '../../lux-directives/lux-tag-id/lux-tag-id.directive';
@@ -44,6 +45,7 @@ import { LuxMenuTriggerComponent } from './lux-menu-subcomponents/lux-menu-trigg
     NgTemplateOutlet,
     LuxButtonComponent,
     LuxTabIndexDirective,
+    LuxAriaDisabledDirective,
     LuxAriaLabelDirective,
     LuxTooltipDirective,
     NgClass,
@@ -287,6 +289,14 @@ export class LuxMenuComponent implements AfterViewInit, AfterContentInit, AfterV
    * @param event
    */
   menuItemClicked(menuItem: LuxMenuItemComponent, event: Event) {
+    // aria-disabled Items führen die Aktion nicht aus, bleiben aber sichtbar und
+    // fokussierbar. Analog zum LuxButton wird stattdessen luxClickNotAllowed emittiert.
+    if (menuItem.luxDisabledAria && !menuItem.luxDisabled) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      menuItem.clickNotAllowed(event);
+      return;
+    }
     menuItem.clicked(event);
   }
 

--- a/projects/lux-components-lib/src/lib/lux-directives/lux-aria/lux-aria-disabled.directive.ts
+++ b/projects/lux-components-lib/src/lib/lux-directives/lux-aria/lux-aria-disabled.directive.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, Directive, Input } from '@angular/core';
+import { AfterViewChecked, Directive, input } from '@angular/core';
 import { LuxAriaBase } from './lux-aria-base';
 
 /**
@@ -15,27 +15,21 @@ import { LuxAriaBase } from './lux-aria-base';
 })
 export class LuxAriaDisabledDirective extends LuxAriaBase<string> implements AfterViewChecked {
   protected ariaTagName = 'aria-disabled';
-  _luxAriaDisabled?: string;
 
-  @Input() luxAriaDisabledSelector?: string;
+  luxAriaDisabledSelector = input<string | undefined>();
+  luxAriaDisabled = input<string | undefined>();
 
-  @Input()
-  get luxAriaDisabled() {
-    return this._luxAriaDisabled;
-  }
-
-  set luxAriaDisabled(value: string | undefined) {
-    this._luxAriaDisabled = value;
-
-    this.renderAria();
-  }
+  // Merker, ob diese Direktive das Attribut aktuell gesetzt hat. Nur dann darf es
+  // beim Zurücksetzen des Inputs entfernt werden; ein von einem fremden
+  // Host-Binding geschriebenes Attribut wird nicht angetastet.
+  private applied = false;
 
   getSelector(): string | undefined {
-    return this.luxAriaDisabledSelector;
+    return this.luxAriaDisabledSelector();
   }
 
   getValue(): string | undefined {
-    return this._luxAriaDisabled;
+    return this.luxAriaDisabled();
   }
 
   ngAfterViewChecked(): void {
@@ -43,15 +37,30 @@ export class LuxAriaDisabledDirective extends LuxAriaBase<string> implements Aft
     // Attribut neu, sobald sich ihr eigener Wert ändert (etwa luxDisabled true -> false),
     // ohne dass sich der Wert dieser Direktive geändert hätte. Deshalb wird ein gesetzter
     // Zielwert nach jedem Check-Zyklus abgeglichen und bei Abweichung erneut gesetzt.
-    // Ist kein Wert gesetzt, verwaltet das fremde Host-Binding das Attribut allein.
-    if (!this.init || this._luxAriaDisabled === null || this._luxAriaDisabled === undefined) {
+    // Ist kein Wert gesetzt, verwaltet das fremde Host-Binding das Attribut allein;
+    // nur ein zuvor von dieser Direktive gesetzter Wert wird dann einmalig entfernt.
+    if (!this.init) {
       return;
     }
 
+    const value = this.luxAriaDisabled();
     const selector = this.getSelector();
     const el = selector ? this.elementRef.nativeElement.querySelector(selector) : this.elementRef.nativeElement;
-    if (el && el.getAttribute('aria-disabled') !== this._luxAriaDisabled) {
-      this.renderer.setAttribute(el, 'aria-disabled', this._luxAriaDisabled);
+    if (!el) {
+      return;
     }
+
+    if (value === null || value === undefined) {
+      if (this.applied) {
+        this.renderer.removeAttribute(el, 'aria-disabled');
+        this.applied = false;
+      }
+      return;
+    }
+
+    if (el.getAttribute('aria-disabled') !== value) {
+      this.renderer.setAttribute(el, 'aria-disabled', value);
+    }
+    this.applied = true;
   }
 }

--- a/projects/lux-components-lib/src/lib/lux-directives/lux-aria/lux-aria-disabled.directive.ts
+++ b/projects/lux-components-lib/src/lib/lux-directives/lux-aria/lux-aria-disabled.directive.ts
@@ -1,0 +1,38 @@
+import { Directive, Input } from '@angular/core';
+import { LuxAriaBase } from './lux-aria-base';
+
+/**
+ * Setzt "aria-disabled" per Renderer2 am Host- oder einem per Selector gewählten
+ * Kindelement. Nötig statt eines [attr.aria-disabled]-Template-Bindings, weil
+ * Material-Komponenten (z.B. MatButton, MatMenuItem) dasselbe Attribut per
+ * Host-Binding verwalten und einen initial gesetzten Template-Wert im ersten
+ * Change-Detection-Zyklus wieder überschreiben würden.
+ */
+@Directive({
+  selector: '[luxAriaDisabled]'
+})
+export class LuxAriaDisabledDirective extends LuxAriaBase<string> {
+  protected ariaTagName = 'aria-disabled';
+  _luxAriaDisabled?: string;
+
+  @Input() luxAriaDisabledSelector?: string;
+
+  @Input()
+  get luxAriaDisabled() {
+    return this._luxAriaDisabled;
+  }
+
+  set luxAriaDisabled(value: string | undefined) {
+    this._luxAriaDisabled = value;
+
+    this.renderAria();
+  }
+
+  getSelector(): string | undefined {
+    return this.luxAriaDisabledSelector;
+  }
+
+  getValue(): string | undefined {
+    return this._luxAriaDisabled;
+  }
+}

--- a/projects/lux-components-lib/src/lib/lux-directives/lux-aria/lux-aria-disabled.directive.ts
+++ b/projects/lux-components-lib/src/lib/lux-directives/lux-aria/lux-aria-disabled.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { AfterViewChecked, Directive, Input } from '@angular/core';
 import { LuxAriaBase } from './lux-aria-base';
 
 /**
@@ -6,12 +6,14 @@ import { LuxAriaBase } from './lux-aria-base';
  * Kindelement. Nötig statt eines [attr.aria-disabled]-Template-Bindings, weil
  * Material-Komponenten (z.B. MatButton, MatMenuItem) dasselbe Attribut per
  * Host-Binding verwalten und einen initial gesetzten Template-Wert im ersten
- * Change-Detection-Zyklus wieder überschreiben würden.
+ * Change-Detection-Zyklus wieder überschreiben würden. MatButton bietet zwar
+ * einen eigenen aria-disabled-Input an, MatMenuItem aber nicht; die Direktive
+ * deckt beide Fälle einheitlich ab.
  */
 @Directive({
   selector: '[luxAriaDisabled]'
 })
-export class LuxAriaDisabledDirective extends LuxAriaBase<string> {
+export class LuxAriaDisabledDirective extends LuxAriaBase<string> implements AfterViewChecked {
   protected ariaTagName = 'aria-disabled';
   _luxAriaDisabled?: string;
 
@@ -34,5 +36,22 @@ export class LuxAriaDisabledDirective extends LuxAriaBase<string> {
 
   getValue(): string | undefined {
     return this._luxAriaDisabled;
+  }
+
+  ngAfterViewChecked(): void {
+    // Fremde Host-Bindings (z.B. MatMenuItem: aria-disabled = disabled) schreiben das
+    // Attribut neu, sobald sich ihr eigener Wert ändert (etwa luxDisabled true -> false),
+    // ohne dass sich der Wert dieser Direktive geändert hätte. Deshalb wird ein gesetzter
+    // Zielwert nach jedem Check-Zyklus abgeglichen und bei Abweichung erneut gesetzt.
+    // Ist kein Wert gesetzt, verwaltet das fremde Host-Binding das Attribut allein.
+    if (!this.init || this._luxAriaDisabled === null || this._luxAriaDisabled === undefined) {
+      return;
+    }
+
+    const selector = this.getSelector();
+    const el = selector ? this.elementRef.nativeElement.querySelector(selector) : this.elementRef.nativeElement;
+    if (el && el.getAttribute('aria-disabled') !== this._luxAriaDisabled) {
+      this.renderer.setAttribute(el, 'aria-disabled', this._luxAriaDisabled);
+    }
   }
 }

--- a/projects/lux-components-lib/src/public_api.ts
+++ b/projects/lux-components-lib/src/public_api.ts
@@ -21,6 +21,7 @@ export * from './lib/lux-action/lux-menu/lux-menu.component';
  */
 export * from './lib/lux-directives/lux-aria/lux-aria-base';
 export * from './lib/lux-directives/lux-aria/lux-aria-describedby.directive';
+export * from './lib/lux-directives/lux-aria/lux-aria-disabled.directive';
 export * from './lib/lux-directives/lux-aria/lux-aria-expanded.directive';
 export * from './lib/lux-directives/lux-aria/lux-aria-haspopup.directive';
 export * from './lib/lux-directives/lux-aria/lux-aria-hidden.directive';


### PR DESCRIPTION
Closes #268

## Was wurde umgesetzt

- `luxDisabledAria` ist von `LuxButtonComponent` in die `LuxActionComponentBaseClass` gewandert und steht damit auch `lux-menu-item` zur Verfügung; dort neu: `luxClickNotAllowed` als Output.
- Sichtbare Menü-Buttons reichen `luxDisabledAria`/`luxClickNotAllowed` an den `lux-button` durch; die Overflow-Panel-Items erhalten `aria-disabled="true"` ohne natives `disabled` (bleiben fokussierbar und pfeiltasten-navigierbar) plus Klick-Guard in `menuItemClicked()`: Klick/Enter emittiert `luxClickNotAllowed` statt `luxClicked`, das Panel bleibt offen.
- Kein Styling, gemäß Richtlinie: aria-disabled Items sehen wie normale Items aus, die Anwendung reagiert über `luxClickNotAllowed`.
- Neue `LuxAriaDisabledDirective` (lux-aria-Familie): Material verwaltet `aria-disabled` an MatButton und MatMenuItem per Host-Binding und überschreibt ein initial gesetztes `[attr.aria-disabled]`-Template-Binding im ersten Change-Detection-Zyklus. Die Direktive setzt das Attribut nach dem View-Init und gleicht es nach fremden Schreibern wieder ab. Das behebt nebenbei einen bestehenden Fehler im `lux-button`: Bei initial gesetztem `luxDisabledAria` fehlte das Attribut bisher komplett (Screenreader bekamen den Zustand nie angesagt). Falls es in konsumierenden Projekten dafür Workarounds gibt, können diese mit 21.8.0 entfernt werden.
- Demo-Beispiel (Toggle `luxDisabledAria` pro Menu-Item, `luxClickNotAllowed` wird geloggt) und Changelog-Eintrag in neuer Sektion 21.8.0.

## Hinweise für Reviewer

- Kein API-Bruch: `luxDisabledAria` heißt, typt und defaulted wie bisher (jetzt vererbt); `LuxAriaDisabledDirective` ist additiv.
- `lux-link`/`lux-link-plain` erben den Input, werten ihn aber noch nicht aus (JSDoc-Hinweis vorhanden); eine Verdrahtung könnte bei Bedarf als separates Issue folgen.

## Tests

- Komplette Library-Suite: 1052/1052 grün (ChromeHeadless).
- Neu: 5 Menü-Tests (aria-disabled sichtbar/Panel, Klick-Guard, luxDisabled-Regression), 3 Härtungstests (Host-Binding-Wertwechsel, Attribut-Entfernung, luxHidden-Regression), 1 Button-Regressionstest (initial gesetztes luxDisabledAria).
